### PR TITLE
Create factory for OAuthStorage

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -8,6 +8,11 @@ import { AuthGuard } from './auth-guard.service';
 import { authModuleConfig } from './auth-module-config';
 import { AuthService } from './auth.service';
 
+// We need a factory since localStorage is not available at AOT build time
+export function storageFactory() : OAuthStorage {
+  return localStorage
+}
+
 @NgModule({
   imports: [
     HttpClientModule,
@@ -27,7 +32,7 @@ export class CoreModule {
         { provide: AuthConfig, useValue: authConfig },
         { provide: OAuthModuleConfig, useValue: authModuleConfig },
         { provide: ValidationHandler, useClass: JwksValidationHandler },
-        { provide: OAuthStorage, useValue: localStorage },
+        { provide: OAuthStorage, useFactory: storageFactory },
       ]
     };
   }


### PR DESCRIPTION
localStorage is not available at AOT build time, so we need to wrap it into a factory. It is then executed only at runtime in the browser.

Fixes #12