### PR TITLE
Identityserver encoding state fix

### DIFF
--- a/src/app/core/auth-config.ts
+++ b/src/app/core/auth-config.ts
@@ -11,5 +11,6 @@ export const authConfig: AuthConfig = {
   timeoutFactor: 0.25, // For faster testing
   sessionChecksEnabled: true,
   showDebugInformation: true, // Also requires enabling "Verbose" level in devtools
-  clearHashAfterLogin: false, // https://github.com/manfredsteyer/angular-oauth2-oidc/issues/457#issuecomment-431807040
+  clearHashAfterLogin: false, // https://github.com/manfredsteyer/angular-oauth2-oidc/issues/457#issuecomment-431807040,
+  nonceStateSeparator : 'semicolon' // Real semicolon gets mangled by IdentityServer's URI encoding
 };

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -150,8 +150,12 @@ export class AuthService {
         // login(...) should never have this, but in case someone ever calls
         // initImplicitFlow(undefined | null) this could happen.
         if (this.oauthService.state && this.oauthService.state !== 'undefined' && this.oauthService.state !== 'null') {
-          console.log('There was state, so we are sending you to: ' + this.oauthService.state);
-          this.router.navigateByUrl(this.oauthService.state);
+          let stateUrl = this.oauthService.state;
+          if (stateUrl.startsWith('/') === false) {
+            stateUrl = decodeURIComponent(stateUrl);
+          }
+          console.log(`There was state of ${this.oauthService.state}, so we are sending you to: ${stateUrl}`);
+          this.router.navigateByUrl(stateUrl);
         }
       })
       .catch(() => this.isDoneLoadingSubject$.next(true));


### PR DESCRIPTION
Using IdentityServer with the code flow 'mangles' the return URL somewhere with URI encoding.

See screencap: 
![oidc](https://user-images.githubusercontent.com/1412705/75139033-ed7e4480-56eb-11ea-8ad6-d12736692c50.gif)

`/extras/admin2`gets turned into `%2Fextras%2Fadmin2`
