### PR TITLE
re-enable jasmine tests

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -55,6 +55,18 @@
             }
           }
         },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "src/test.ts",
+            "tsConfig": "src/tsconfig.spec.json",
+            "karmaConfig": "karma.conf.js",
+            "watch": false,
+            "codeCoverageExclude": [
+              "src/testing/*"
+            ]
+          }
+        },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function (config) {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
     coverageIstanbulReporter: {
-      dir: require('path').join(__dirname, './coverage/FooBar'),
+      dir: require('path').join(__dirname, './coverage/sample-auth-guards'),
       reports: ['html', 'lcovonly', 'text-summary'],
       fixWebpackSourcePaths: true
     },
@@ -25,7 +25,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: [process.env.CI ? 'ChromeHeadless' : 'Chrome'],
     singleRun: false,
     restartOnFileChange: true
   });

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "lint": "ng lint",
+    "test": "ng test",
     "e2e": "ng e2e"
   },
   "private": true,

--- a/src/app/core/auth.service.spec.ts
+++ b/src/app/core/auth.service.spec.ts
@@ -1,0 +1,6 @@
+
+describe('AuthService', () => {
+  it('should pass', () => {
+    expect(true).toBeTruthy();
+  });
+});

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,21 @@
+// This file is required by karma.conf.js and loads recursively all the .spec and framework files
+
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+import 'zone.js/dist/zone';
+import 'zone.js/dist/zone-testing';
+
+declare const require: any;
+
+// First, initialize the Angular testing environment.
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);
+// Then we find all the tests.
+const context = require.context('./', true, /\.spec\.ts$/);
+// And load the modules.
+context.keys().map(context);

--- a/src/tsconfig.spec.json
+++ b/src/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../out-tsc/spec",
+    "types": ["jasmine", "node"]
+  },
+  "files": ["test.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}


### PR DESCRIPTION
Implements first step in #60 

- Added basic jasmine setup for angular tests
- Updated `angular.json` and `package.json` to run unit tests