### PR TITLE
109: Switch IdentityServer for E2E tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository uses that technique currently, [starting with a `silentRefresh()
 This will fire up an iframe to load an IDS page with `noprompt`, hoping cookies get sent along to so the IDS can see if a user is logged in.
 
 [Safari will block cookies from being sent](https://webkit.org/blog/10218/full-third-party-cookie-blocking-and-more/), prompting a leading OAuth/OpenID community member to write "[SPAs are dead!?](https://leastprivilege.com/2020/03/31/spas-are-dead/)".
-In fact, if you fire up this sample repository on `localhost`, which talks to `demo.identityserver.io` (another domain!), and use it in Safari: you will notice that the silent refresh technique already fails!
+In fact, if you fire up this sample repository on `localhost`, which talks to `demo.duendesoftware.com` (another domain!), and use it in Safari: you will notice that the silent refresh technique already fails!
 
 For reference, see [issue #40](https://github.com/jeroenheijmans/sample-angular-oauth2-oidc-with-auth-guards/issues/40), or [my blogpost that explains workarounds and solutions](https://infi.nl/nieuws/spa-necromancy/).
 
@@ -53,7 +53,7 @@ To use the repository:
 1. Run `npm install` to get the dependencies
 1. Run `npm run start` (or `start-with-ssl`) to get it running on [http://localhost:4200](http://localhost:4200) (or [https://localhost:4200](https://localhost:4200))
 
-This connects to the [demo IdentityServer4 instance](https://demo.identityserver.io/) also used in the library's examples.
+This connects to the [demo Duende IdentityServer instance](https://demo.duendesoftware.com/) also used in the library's examples.
 The **credentials** and ways of logging in are disclosed on the login page itself (as it's only a demo server).
 
 You could also connect to your own IdentityServer by changing `auth-config.ts`.
@@ -61,7 +61,7 @@ Note that your server must whitelist both `http://localhost:4200/index.html` and
 
 ## Differences between Identity Server options
 
-**This repository demonstrates features using https://demo.identityserver.io (IdentityServer4)**.
+**This repository demonstrates features using https://demo.duendesoftware.com (Duende IdentityServer)**.
 There are various other server side solutions available, each with their own intricacies.
 This codebase does not keep track itself of the specifics for each other server side solution.
 Instead, we recommend you look for specific guidance for other solutions elsewhere.

--- a/e2e/src/demo-identityserver.po.ts
+++ b/e2e/src/demo-identityserver.po.ts
@@ -1,14 +1,14 @@
 import { browser, by, element } from 'protractor';
 
-export class DemoIdentityServer4Page {
+export class DemoIdentityServerPage {
   isReadyForLoginInputs(): Promise<boolean> {
-    return element(by.css('input#Username'))
+    return element(by.css('input#Input_Username'))
       .isPresent() as Promise<boolean>;
   }
 
   async enterCredentials(user: string, password: string): Promise<void> {
-    await element(by.css('input#Username')).sendKeys(user);
-    await element(by.css('input#Password')).sendKeys(password);
+    await element(by.css('input#Input_Username')).sendKeys(user);
+    await element(by.css('input#Input_Password')).sendKeys(password);
     await element(by.css('button[value=login]')).click();
   }
 

--- a/e2e/src/happy-path-flow.e2e-spec.ts
+++ b/e2e/src/happy-path-flow.e2e-spec.ts
@@ -1,16 +1,16 @@
 import { browser } from 'protractor';
 
 import { AppPage } from './app.po';
-import { DemoIdentityServer4Page } from './demo-identityserver4.po';
+import { DemoIdentityServerPage } from './demo-identityserver.po';
 import { assertNoUnexpectedBrowserErrorsOnConsole } from './util';
 
 describe('Happy Path Flow', () => {
   let appPage: AppPage;
-  let ids4Page: DemoIdentityServer4Page;
+  let identityServerPage: DemoIdentityServerPage;
 
   beforeEach(() => {
     appPage = new AppPage();
-    ids4Page = new DemoIdentityServer4Page();
+    identityServerPage = new DemoIdentityServerPage();
   });
 
   it('should start at home', async () => {
@@ -34,11 +34,11 @@ describe('Happy Path Flow', () => {
   it('should be able to navigate to IDS4', async () => {
     await appPage.clickLoginButton();
     browser.waitForAngularEnabled(false);
-    expect(await ids4Page.isReadyForLoginInputs()).toBe(true);
+    expect(await identityServerPage.isReadyForLoginInputs()).toBe(true);
   });
 
   it('should be able to log in on IDS4', async () => {
-    await ids4Page.enterCredentials('bob', 'bob');
+    await identityServerPage.enterCredentials('bob', 'bob');
     browser.waitForAngularEnabled(true);
   });
 
@@ -59,7 +59,7 @@ describe('Happy Path Flow', () => {
 
   it('should show expected identity claims', async () => {
     const identityClaims = await appPage.getShownDebugValue('identityClaims');
-    expect(identityClaims).toContain('"iss": "https://demo.identityserver.io"');
+    expect(identityClaims).toContain('"iss": "https://demo.duendesoftware.com"');
     expect(identityClaims).toContain('"name": "Bob Smith"');
   });
 
@@ -73,11 +73,11 @@ describe('Happy Path Flow', () => {
   it('should be able to log out via IDS4', async () => {
     await appPage.clickLogoutButton();
     browser.waitForAngularEnabled(false);
-    expect(await ids4Page.isShowingLoggedOutMessage()).toBe(true);
+    expect(await identityServerPage.isShowingLoggedOutMessage()).toBe(true);
   });
 
   it('should be able to return to the app', async () => {
-    await ids4Page.clickReturnToAppUrl();
+    await identityServerPage.clickReturnToAppUrl();
     browser.waitForAngularEnabled(true);
   });
 

--- a/src/app/core/auth-config.ts
+++ b/src/app/core/auth-config.ts
@@ -1,7 +1,7 @@
 import { AuthConfig } from 'angular-oauth2-oidc';
 
 export const authConfig: AuthConfig = {
-  issuer: 'https://demo.identityserver.io',
+  issuer: 'https://demo.duendesoftware.com',
   clientId: 'interactive.public', // The "Auth Code + PKCE" client
   responseType: 'code',
   redirectUri: window.location.origin + '/',
@@ -13,5 +13,5 @@ export const authConfig: AuthConfig = {
   sessionChecksEnabled: true,
   showDebugInformation: true, // Also requires enabling "Verbose" level in devtools
   clearHashAfterLogin: false, // https://github.com/manfredsteyer/angular-oauth2-oidc/issues/457#issuecomment-431807040,
-  nonceStateSeparator : 'semicolon' // Real semicolon gets mangled by IdentityServer's URI encoding
+  nonceStateSeparator : 'semicolon' // Real semicolon gets mangled by Duende ID Server's URI encoding
 };

--- a/src/app/core/auth-module-config.ts
+++ b/src/app/core/auth-module-config.ts
@@ -2,7 +2,7 @@ import { OAuthModuleConfig } from 'angular-oauth2-oidc';
 
 export const authModuleConfig: OAuthModuleConfig = {
   resourceServer: {
-    allowedUrls: ['https://demo.identityserver.io/api'],
+    allowedUrls: ['https://demo.duendesoftware.com/api'],
     sendAccessToken: true,
   }
 };

--- a/src/app/shared/api.service.ts
+++ b/src/app/shared/api.service.ts
@@ -8,7 +8,7 @@ export class ApiService {
   constructor(private http: HttpClient) { }
 
   getProtectedApiResponse(): Observable<string> {
-    return this.http.get<any>('https://demo.identityserver.io/api/test')
+    return this.http.get<any>('https://demo.duendesoftware.com/api/test')
       .pipe(
         map(response => response.find((i: any) => i.type === 'iss').value),
         map(iss => '☁ API Success from ' + iss),


### PR DESCRIPTION
IdentityServer4 has become Duende Identity Server, and they switched
over the demo instance to a new location. They also tweaked some
html on the login form requiring changes to the tests.

It's tempting to switch over to a locally running NPM based OIDC server
for stability, but then again the Duende folks are so great at building
and running IDS that it seems worth it to stick with that one as long
as it conveniently lasts.

Fixes #109