### PR TITLE
Update ci-workflow.yml to use GitHub Actions V3

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -14,11 +14,11 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Based on: https://docs.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows#example-using-the-cache-action
     - name: Cache node modules
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: cache-node-modules
       with:


### PR DESCRIPTION
GitHub Actions V2 has been deprecated and are replaced with V3.

You can see warnings in the action runs, e.g. https://github.com/jeroenheijmans/sample-angular-oauth2-oidc-with-auth-guards/actions/runs/5273599747

## Additional context
- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/